### PR TITLE
fix: [inject_evaluator] Return false for contains-regex if there are …

### DIFF
--- a/inject_evaluator.py
+++ b/inject_evaluator.py
@@ -93,7 +93,9 @@ def eval_condition_list(evaluation_config: dict, data_to_validate: str, context:
         for candidate in data_to_validate:
             if regex.match(candidate) is None:
                 return False
-        return True
+            else:
+                return True
+        return False
     elif comparison_type == 'count':
         return count_comparison(values, data_to_validate)
     return False


### PR DESCRIPTION
…no candidates in data to evaluate

### fixes: contains-regex returns True if there are no matching attributes
For example in default Scam Scenario for Phone Number step, just create an event with scam call in event info, then add a comment attribute with any text. The step will be considered done.


I don't know what the hell is going on with the file ending. I did an edit from github :/ . If you can fix that, that would be great. If not I'll check to solve that later.