### PR TITLE
fix: use sys.executable instead of hardcoded venv path

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -519,7 +519,7 @@ async def backup_exercises_progress():
 
 
 def start_sandbox_agent():
-    bin_path = os.path.abspath("./venv/bin/python3")
+    bin_path = sys.executable
     script_path = os.path.abspath("./backend/sandboxAgent.py")
     process = subprocess.Popen(
         [bin_path, script_path],


### PR DESCRIPTION
The sandbox agent launcher used a hardcoded `./venv/bin/python3` path,
which caused FileNotFoundError inside Docker where no virtualenv exists.
Using sys.executable ensures it runs with the correct Python interpreter
in any environment.