### PR TITLE
Fix install by removing venv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,7 @@ RUN apt-get update \
     && apt-get purge -y --auto-remove \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python3 -m venv /app/venv \
-    && /app/venv/bin/pip install --upgrade pip setuptools \
-    && /app/venv/bin/pip install -r backend/requirements.txt
-
-ENV VIRTUAL_ENV=/app/venv
-ENV PATH="/app/venv/bin:${PATH}"
+RUN pip install --upgrade pip setuptools && pip install -r backend/requirements.txt
 
 WORKDIR /app/backend
 RUN cp config.py.sample config.py

--- a/backend/server.py
+++ b/backend/server.py
@@ -519,7 +519,7 @@ async def backup_exercises_progress():
 
 
 def start_sandbox_agent():
-    bin_path = os.path.abspath("./venv/bin/python3")
+    bin_path = "python3"
     script_path = os.path.abspath("./backend/sandboxAgent.py")
     process = subprocess.Popen(
         [bin_path, script_path],


### PR DESCRIPTION
# What is this PR?
This pull request fixes the broken state of the repository's installation pipeline.
After this pull request a similar pull request from me on the main SkillAegis repo should be accepted to reflect these changes there as well. 

## Additional details
Personally, I saw no value for using venv here at all as most people will use Docker.
backend/server.py might need finetuning for the local installation approach in the future if venv use cases arise.
At least this PR fixes the current broken state to support most use cases.

I have tested that both local and docker installation methods work after this fix.